### PR TITLE
Add regex-style tuple matching with accessmatch function

### DIFF
--- a/src/SeeSign.jl
+++ b/src/SeeSign.jl
@@ -6,7 +6,8 @@ include("tracked.jl")
 include("depnet.jl")
 include("framework.jl")
 include("sim.jl")
+include("regex_tuples.jl")
 
-export StepArray, changed, previous_value, accept, @react
+export StepArray, changed, previous_value, accept, @react, ℤ, ℤ⁺, accessmatch
 
 end

--- a/src/regex_tuples.jl
+++ b/src/regex_tuples.jl
@@ -1,0 +1,49 @@
+const ℤ = :__SINGLE_INTEGER_MATCH__
+const ℤ⁺ = :__MULTIPLE_INTEGER_MATCH__
+
+function validate_pattern(pattern::Vector)
+    for i in 1:(length(pattern)-1)
+        if (pattern[i] === ℤ || pattern[i] === ℤ⁺) && 
+           (pattern[i+1] === ℤ || pattern[i+1] === ℤ⁺) &&
+           pattern[i] !== pattern[i+1]
+            throw(ArgumentError("Cannot mix consecutive ℤ and ℤ⁺ patterns"))
+        end
+    end
+end
+
+function accessmatch(pattern::Vector, input::Tuple)
+    validate_pattern(pattern)
+    captures = Tuple{Int,Vararg{Int}}[]
+    input_idx = 1
+    
+    for elem in pattern
+        if input_idx > length(input)
+            return nothing
+        end
+        
+        if elem === ℤ
+            # Consume exactly one integer
+            if input_idx > length(input) || !isa(input[input_idx], Integer)
+                return nothing
+            end
+            push!(captures, (input[input_idx],))
+            input_idx += 1
+        elseif elem === ℤ⁺
+            # Consume one or more consecutive integers
+            integers = Int[]
+            while input_idx ≤ length(input) && isa(input[input_idx], Integer)
+                push!(integers, input[input_idx])
+                input_idx += 1
+            end
+            isempty(integers) && return nothing
+            push!(captures, Tuple(integers))
+        elseif isa(elem, Symbol)
+            input[input_idx] === elem || return nothing
+            input_idx += 1
+        else
+            throw(ArgumentError("Pattern must contain only symbols, ℤ, and ℤ⁺ but found $elem"))
+        end
+    end
+    
+    return input_idx > length(input) ? Tuple(captures) : nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 
 @testset "SeeSign.jl" begin
     include("test_parse.jl")
+    include("test_regex_tuples.jl")
     include("test_changed.jl")
     include("test_indexmath.jl")
     include("test_depnet.jl")

--- a/test/test_regex_tuples.jl
+++ b/test/test_regex_tuples.jl
@@ -1,0 +1,72 @@
+using Test
+using SeeSign
+
+
+@testset "Base smoke test for regex tuples" begin
+    # This is a kind of regular expression. It matches tuples that contain
+    # only symbols and integers. We can't use a normal string-based regular expression
+    # but we can make a list of elements in the regular expression. There are three kinds
+    # of search terms: exact match of a symbol, ℤ which matches exactly one integer,
+    # or ℤ⁺ which matches one or more integers in the tuple.
+    test_cases = [
+        ([:board, ℤ, :location], (:board, 3, :location), ((3,),)),
+        ([:boo, ℤ, :habit], (:boo, 5, :habit), ((5,),)),
+        ([:boo, ℤ⁺, :habit], (:boo, 5, 7, :habit), ((5, 7),)),
+        ([:board, ℤ, :location], (:board, 3, :folly), nothing),
+        ([:board, ℤ, :location], (:peanuts, 3, :location), nothing),
+        ([:agent, ℤ⁺], (:agent, 3, 4, 7), ((3, 4, 7),)),
+    ]
+    for (pattern, input, oracle) in test_cases
+        match_result = accessmatch(pattern, input)
+        @test match_result == oracle
+    end
+end
+
+@testset "Edge cases and comprehensive tests" begin
+    # Empty patterns and inputs
+    @test accessmatch([], ()) == ()
+    @test accessmatch([], (:a,)) === nothing
+    
+    # Just literals
+    @test accessmatch([:a, :b], (:a, :b)) == ()
+    @test accessmatch([:a, :b], (:a, :c)) === nothing
+    
+    # Just integers - single vs multiple
+    @test accessmatch([ℤ], (42,)) == ((42,),)
+    @test accessmatch([ℤ], (1, 2)) === nothing  # ℤ matches exactly one
+    @test accessmatch([ℤ⁺], (1, 2, 3)) == ((1, 2, 3),)
+    @test accessmatch([ℤ⁺], (:a,)) === nothing
+    
+    # Multiple captures now work with both ℤ and ℤ⁺
+    
+    # Integer at start
+    @test accessmatch([ℤ⁺, :end], (1, 2, :end)) == ((1, 2),)
+    @test accessmatch([ℤ, :end], (1, :end)) == ((1,),)
+    
+    # Integer at end  
+    @test accessmatch([:start, ℤ⁺], (:start, 1, 2)) == ((1, 2),)
+    @test accessmatch([:start, ℤ], (:start, 1)) == ((1,),)
+    
+    # Multiple integer captures
+    @test accessmatch([:start, ℤ, :two, ℤ], (:start, 1, :two, 7)) == ((1,), (7,))
+    @test accessmatch([:start, ℤ⁺, :two, ℤ⁺], (:start, 1, 2, :two, 7, 8)) == ((1, 2), (7, 8))
+    
+    # Consecutive ℤ patterns (same type only)
+    @test accessmatch([ℤ, ℤ], (1, 2)) == ((1,), (2,))
+    @test accessmatch([ℤ, ℤ, ℤ], (1, 2, 3)) == ((1,), (2,), (3,))
+    @test accessmatch([ℤ, ℤ], (1, 2, 3)) === nothing  # Too many integers for two single ℤ
+    
+    # Mixed consecutive integer patterns should throw errors
+    @test_throws ArgumentError accessmatch([ℤ⁺, ℤ], (1, 2, 3))
+    @test_throws ArgumentError accessmatch([ℤ, ℤ⁺], (1, 2, 3))
+
+    # Mixed types that should fail
+    @test accessmatch([:a, ℤ, :b], (:a, "string", :b)) === nothing
+    
+    # Complex pattern  
+    @test accessmatch([:prefix, ℤ⁺, :suffix], 
+               (:prefix, 1, 2, 3, :suffix)) == ((1, 2, 3),)
+    @test accessmatch([:prefix, ℤ, :suffix], 
+               (:prefix, 1, :suffix)) == ((1,),)
+end
+


### PR DESCRIPTION
Implements pattern matching for tuples containing symbols and integers:
- ℤ matches exactly one integer
- ℤ⁺ matches one or more consecutive integers
- Validates patterns to prevent ambiguous consecutive ℤ/ℤ⁺ combinations
- Simple linear scan algorithm without backtracking
- Comprehensive test coverage for edge cases

🤖 Generated with [Claude Code](https://claude.ai/code)